### PR TITLE
Revert to former approach to deploy pages 

### DIFF
--- a/.github/workflows/build-hugo.yml
+++ b/.github/workflows/build-hugo.yml
@@ -1,13 +1,19 @@
-name: Build Hugo website
+name: Deploy Hugo site to Pages
 
 on:
   push:
     branches: ["main"]
 
+  pull_request:
+    branches: ["main"]
+
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -25,7 +31,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      # Note: There are breaking changes with some later versions of hugo
       HUGO_VERSION: 0.128.0
     steps:
       - name: Install Hugo CLI
@@ -51,10 +56,19 @@ jobs:
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
-      - name: Push to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          publish_branch: gh-pages
-          force_orphan: true  # Creates a clean gh-pages branch with just the latest build
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Revert to former approach to deploy pages without pushing to a separate branch